### PR TITLE
keep VideoPlayer component mounted

### DIFF
--- a/backend/room.ts
+++ b/backend/room.ts
@@ -112,7 +112,7 @@ class Room {
   async playContent(client: Socket, source: string, startFrom: number) {
     this.source = source ? await resolveContent(source, startFrom) : undefined
     this.lastSeekedTo = startFrom
-    this.paused = false
+    // this.paused = false
     this.broadcast.emit("source", this.source)
     // this.resume()
 

--- a/src/components/VideoPlayer.ts
+++ b/src/components/VideoPlayer.ts
@@ -113,8 +113,18 @@ export default defineComponent({
       })
       offHandlers.push(offRequestTime)
 
-      // const offSource = resync.onSource(play)
-      // offHandlers.push(offSource)
+      const offSource = resync.onSource(() => {
+        if (!video.value) throw new Error("video ref is null")
+        autoplay.value = false
+
+        video.value.oncanplaythrough = () => {
+          resync.loaded()
+
+          if (!video.value) throw new Error("video ref is null")
+          video.value.oncanplaythrough = null
+        }
+      })
+      offHandlers.push(offSource)
 
       const offVolume = watch(resync.volume, volume => {
         video.value && (video.value.volume = volume)

--- a/src/components/VideoPlayer.ts
+++ b/src/components/VideoPlayer.ts
@@ -156,16 +156,16 @@ export default defineComponent({
     onBeforeUnmount(() => offHandlers.forEach(off => off()))
 
     return () => {
-      if (src.value)
-        return h("video", {
-          src: src.value,
-          ref: video,
-          disablePictureInPicture: true,
-          preload: "auto",
-          muted: muted.value,
-          autoplay: autoplay.value,
-        })
-      else return
+      // if (src.value)
+      return h("video", {
+        src: src.value,
+        ref: video,
+        disablePictureInPicture: true,
+        preload: "auto",
+        muted: muted.value,
+        autoplay: autoplay.value,
+      })
+      // else return
     }
   },
 })

--- a/src/components/VideoPlayer.ts
+++ b/src/components/VideoPlayer.ts
@@ -45,6 +45,8 @@ export default defineComponent({
 
       video.value.volume = resync.muted.value ? 0 : resync.volume.value
 
+      console.log("mounted state", resync.state.value.paused)
+
       if (resync.state.value.paused) {
         autoplay.value = false
         video.value.currentTime = resync.state.value.lastSeekedTo
@@ -111,8 +113,8 @@ export default defineComponent({
       })
       offHandlers.push(offRequestTime)
 
-      const offSource = resync.onSource(play)
-      offHandlers.push(offSource)
+      // const offSource = resync.onSource(play)
+      // offHandlers.push(offSource)
 
       const offVolume = watch(resync.volume, volume => {
         video.value && (video.value.volume = volume)

--- a/src/resync.ts
+++ b/src/resync.ts
@@ -103,6 +103,7 @@ export default class Resync {
   playContent = (source: string): void => {
     this.roomEmit("playContent", { source })
   }
+  loaded = (): void => this.roomEmit("loaded")
   pause = (currentTime: number): void => {
     this.roomEmit("pause", { currentTime })
   }

--- a/src/resync.ts
+++ b/src/resync.ts
@@ -2,7 +2,7 @@ import type { Socket } from "socket.io-client"
 import type { BackendEmits, FrontendEmits, RoomEmit, RoomState } from "$/room"
 
 import { Ref, ref, watch } from "vue"
-import { capitalize, debug, ls, once } from "./util"
+import { capitalize, debug, ls } from "./util"
 
 const log = debug("resync.ts")
 
@@ -71,11 +71,15 @@ export default class Resync {
     })
   }
 
-  joinRoom = once((name: string): void => {
+  joinRoom = async (name: string): Promise<void> => {
     const join = () => {
-      this.roomEmit("joinRoom", { name }, state => {
-        log("initial room state", state)
-        this.state.value = state
+      return new Promise<void>(res => {
+        this.roomEmit("joinRoom", { name }, state => {
+          log("initial room state", state)
+          this.state.value = state
+
+          res()
+        })
       })
     }
 
@@ -93,8 +97,8 @@ export default class Resync {
     this.handlers.push(() => this.socket.off("disconnect", disconnect))
     this.handlers.push(() => this.roomEmit("leaveRoom"))
 
-    join()
-  })
+    await join()
+  }
 
   playContent = (source: string): void => {
     this.roomEmit("playContent", { source })

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -52,11 +52,12 @@ export default defineComponent({
 
     const resetScope = () =>
       sentry.configureScope(scope => {
-      scope.setTag("roomID", null)
-      scope.setTag("name", null)
+        scope.setTag("roomID", null)
+        scope.setTag("name", null)
       })
 
-    resync.joinRoom(name)
+    const mountPlayer = ref(false)
+    resync.joinRoom(name).then(() => (mountPlayer.value = true))
 
     const recentNotifications = ref<EventNotification[]>([])
     const offNotifiy = resync.onNotify(notification => {
@@ -82,6 +83,7 @@ export default defineComponent({
       resync,
       recentNotifications,
       renderNotification,
+      mountPlayer,
     }
   },
 })
@@ -110,7 +112,7 @@ export default defineComponent({
           </button>
         </div>
 
-        <PlayerWrapper v-show="resync.state.value.source" type="video" />
+        <PlayerWrapper v-if="mountPlayer" v-show="resync.state.value.source" type="video" />
       </div>
 
       <div class="top-list left-0">

--- a/src/views/Room.vue
+++ b/src/views/Room.vue
@@ -110,7 +110,7 @@ export default defineComponent({
           </button>
         </div>
 
-        <PlayerWrapper v-if="resync.state.value.source" type="video" />
+        <PlayerWrapper v-show="resync.state.value.source" type="video" />
       </div>
 
       <div class="top-list left-0">

--- a/types/room.d.ts
+++ b/types/room.d.ts
@@ -45,6 +45,7 @@ type FrontendEmitterTime<A = RoomEmitTime, C = void> = (x: RoomEmitTime & A, c: 
 
 export interface FrontendEmits {
   playContent: FrontendEmitterBase<{ source: string; startFrom?: number }>
+  loaded: FrontendEmitterBase
   pause: FrontendEmitterTime
   resume: FrontendEmitterBase
   seekTo: FrontendEmitterTime


### PR DESCRIPTION
this lets the component know if it's joining a running room or if it's just playing a video from a stopped state.
this allows for a feature where start of playback occurs only after all clients have loaded the video enough.